### PR TITLE
알림 리스트와 상세보기 화면 예외처리, 테마별/지역별 혜택 결과 화면 예외처리

### DIFF
--- a/app/src/main/java/com/psj/welfare/Activity/DetailBenefitActivity.java
+++ b/app/src/main/java/com/psj/welfare/Activity/DetailBenefitActivity.java
@@ -161,7 +161,15 @@ public class DetailBenefitActivity extends AppCompatActivity
         {
             Intent intent = getIntent();
             push_welf_name = intent.getStringExtra("name");
-            name_of_benefit.setText(push_welf_name);
+            if (push_welf_name.contains(";; "))
+            {
+                push_welf_name = push_welf_name.replace(";; ", ", ");
+                name_of_benefit.setText(push_welf_name);
+            }
+            else
+            {
+                name_of_benefit.setText(push_welf_name);
+            }
             editor.putString("detail_benefit_name", push_welf_name);
             editor.apply();
         }

--- a/app/src/main/java/com/psj/welfare/Activity/MainTabLayoutActivity.java
+++ b/app/src/main/java/com/psj/welfare/Activity/MainTabLayoutActivity.java
@@ -152,9 +152,8 @@ public class MainTabLayoutActivity extends AppCompatActivity
         });
 
         Intent intent = getIntent();
-        int ddd = intent.getIntExtra("push", -1);
-        Log.e(TAG, "ddd : " + ddd);
-        if (ddd == 100)
+        int push_clicked_value = intent.getIntExtra("push", -1);
+        if (push_clicked_value == 100)
         {
             adapter = new MainViewPagerAdapter(MainTabLayoutActivity.this, getSupportFragmentManager());
             adapter.addFragment(new MainFragment(), "main");

--- a/app/src/main/java/com/psj/welfare/Activity/SplashActivity.java
+++ b/app/src/main/java/com/psj/welfare/Activity/SplashActivity.java
@@ -72,7 +72,6 @@ public class SplashActivity extends AppCompatActivity
                     return;
                 }
                 token = task.getResult().getToken();
-                Log.e(TAG, "FCM token = " + token);
                 editor.putString("fcm_token", token);
                 editor.apply();
             }

--- a/app/src/main/java/com/psj/welfare/Adapter/PushGatherAdapter.java
+++ b/app/src/main/java/com/psj/welfare/Adapter/PushGatherAdapter.java
@@ -57,7 +57,16 @@ public class PushGatherAdapter extends RecyclerView.Adapter<PushGatherAdapter.Pu
     {
         PushGatherItem item = lists.get(position);
         holder.push_gather_title.setText(item.getPush_gather_title());
-        holder.push_gather_desc.setText(item.getWelf_name());
+        String welf_name;
+        if (item.getWelf_name().contains(";; "))
+        {
+            welf_name = item.getWelf_name().replace(";; ", ", ");
+            holder.push_gather_desc.setText(welf_name);
+        }
+        else
+        {
+            holder.push_gather_desc.setText(item.getWelf_name());
+        }
         holder.push_gather_date.setText(item.getPush_gather_date());
 
         ZonedDateTime seoulDateTime = null;

--- a/app/src/main/java/com/psj/welfare/activity/ThemeChooseActivity.java
+++ b/app/src/main/java/com/psj/welfare/activity/ThemeChooseActivity.java
@@ -13,12 +13,9 @@ import android.provider.Settings;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.Button;
-import android.widget.EditText;
-import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.psj.welfare.R;
@@ -31,18 +28,7 @@ public class ThemeChooseActivity extends AppCompatActivity
     private Button[] mButton = new Button[14];
     private ArrayList<Integer> mDataList;
 
-    Button btnJob, btnYoung, btnLiving, btnChild, btnPregnancy, btnCultural, btnCompany, btnHomeless, btnOld, btnDisorder, btnMulticultural, btnLaw, btnMedical, btnEtc;
-
     public final String TAG = "SearchFragment";
-
-    private EditText search_edittext;
-
-    Toolbar search_toolbar;
-
-    TextView recommend_search_textview, recent_search_history_textview;
-
-    TextView main_job_title, main_student_title, main_living_title, main_pregnancy_title, main_child_title, main_cultural_title,
-            main_company_title, main_homeless_title, main_old_title, main_disorder_title, main_multicultural_title, main_law_title;
 
     Button main_job, main_student, main_living, main_pregnancy, main_child, main_cultural, main_company, main_homeless, main_old, main_disorder,
             main_multicultural, main_law, main_medical, main_etc;
@@ -61,24 +47,22 @@ public class ThemeChooseActivity extends AppCompatActivity
         setStatusBarGradiant(ThemeChooseActivity.this);
         setContentView(R.layout.activity_theme_choose);
 
-        search_edittext = findViewById(R.id.search_edittext);
-
         mDataList = new ArrayList<>();
 
-        mButton[0] = (Button) findViewById(R.id.btnJob);
-        mButton[1] = (Button) findViewById(R.id.btnYoung);
-        mButton[2] = (Button) findViewById(R.id.btnLiving);
-        mButton[3] = (Button) findViewById(R.id.btnChild);
-        mButton[4] = (Button) findViewById(R.id.btnPregnancy);
-        mButton[5] = (Button) findViewById(R.id.btnCultural);
-        mButton[6] = (Button) findViewById(R.id.btnCompany);
-        mButton[7] = (Button) findViewById(R.id.btnHomeless);
-        mButton[8] = (Button) findViewById(R.id.btnOld);
-        mButton[9] = (Button) findViewById(R.id.btnDisorder);
-        mButton[10] = (Button) findViewById(R.id.btnMulticultural);
-        mButton[11] = (Button) findViewById(R.id.btnLaw);
-        mButton[12] = (Button) findViewById(R.id.btnMedical);
-        mButton[13] = (Button) findViewById(R.id.btnEtc);
+        mButton[0] = findViewById(R.id.btnJob);
+        mButton[1] = findViewById(R.id.btnYoung);
+        mButton[2] = findViewById(R.id.btnLiving);
+        mButton[3] = findViewById(R.id.btnChild);
+        mButton[4] = findViewById(R.id.btnPregnancy);
+        mButton[5] = findViewById(R.id.btnCultural);
+        mButton[6] = findViewById(R.id.btnCompany);
+        mButton[7] = findViewById(R.id.btnHomeless);
+        mButton[8] = findViewById(R.id.btnOld);
+        mButton[9] = findViewById(R.id.btnDisorder);
+        mButton[10] = findViewById(R.id.btnMulticultural);
+        mButton[11] = findViewById(R.id.btnLaw);
+        mButton[12] = findViewById(R.id.btnMedical);
+        mButton[13] = findViewById(R.id.btnEtc);
 
         main_job = findViewById(R.id.btnJob);
         main_student = findViewById(R.id.btnYoung);

--- a/app/src/main/res/layout/activity_detailbenefit.xml
+++ b/app/src/main/res/layout/activity_detailbenefit.xml
@@ -79,6 +79,8 @@
                 android:id="@+id/name_of_benefit"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:paddingStart="13dp"
+                android:paddingEnd="13dp"
                 android:fontFamily="@font/jalnan"
                 android:textSize="25sp"
                 android:textColor="@color/colorMainWhite"

--- a/app/src/main/res/layout/category_search_result_item.xml
+++ b/app/src/main/res/layout/category_search_result_item.xml
@@ -10,10 +10,10 @@
     android:paddingEnd="25dp"
     android:background="@drawable/shadow_test">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/benefit_layout"
         android:layout_width="match_parent"
-        android:layout_height="130dp"
+        android:layout_height="140dp"
         android:orientation="vertical">
 
         <ImageView
@@ -30,41 +30,40 @@
 
         <TextView
             android:id="@+id/welf_local_textview"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:fontFamily="@font/nanum_barun_gothic_bold"
-            android:paddingLeft="17dp"
-            android:paddingTop="17dp"
-            android:paddingBottom="6dp"
-            android:textColor="#FF7088"
-            android:textSize="16sp"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintWidth_percent="1"
+            app:layout_constraintHeight_percent=".3"
+            app:layout_constraintVertical_bias=".05"
+            android:fontFamily="@font/nanum_barun_gothic_bold"
+            android:gravity="center_vertical"
+            android:paddingStart="17dp"
+            android:text="#광주"
+            android:textColor="@color/layout_background_start_gradation"
+            android:textSize="16sp" />
 
         <TextView
             android:id="@+id/category_search_result_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="4"
-            android:gravity="center_horizontal"
-            android:fontFamily="@font/nanum_barun_gothic_bold"
-            android:lineSpacingExtra="6sp"
-            android:layout_marginLeft="20dp"
-            android:layout_marginRight="20dp"
-            android:padding="10dp"
-            android:shadowColor="@color/colorGray_L"
-            android:shadowDx="-2"
-            android:shadowDy="-2"
-            android:shadowRadius="3"
-            android:textColor="#707070"
-            android:textSize="20sp"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintWidth_percent=".9"
+            app:layout_constraintHeight_percent=".65"
+            app:layout_constraintVertical_bias=".6"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/welf_local_textview"
-            app:layout_constraintVertical_bias="0.2" />
+            android:gravity="center"
+            android:fontFamily="@font/nanum_barun_gothic_bold"
+            android:lineSpacingExtra="6sp"
+            android:text="청년농부"
+            android:textColor="@color/grey"
+            android:textSize="20sp" />
 
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </LinearLayout>


### PR DESCRIPTION
1. 알림 리스트, 상세보기 화면에서 혜택명 부분에 ;; 구분자가 보이는 현상 수정

2. 테마별/지역별 리스트 결과 화면에서 글자 크기가 아이템보다 큰 경우 잘리는 경우 수정

3. 코드 정리, 변수명 변경